### PR TITLE
lint(静的解析) を適用

### DIFF
--- a/.idea/morning_weakers.iml
+++ b/.idea/morning_weakers.iml
@@ -10,6 +10,5 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,10 @@
+# https://pub.dev/packages/pedantic_mono
+include: package:pedantic_mono/analysis_options.yaml
+
+linter:
+  rules:
+    lines_longer_than_80_chars: false
+    omit_local_variable_types: false
+    flutter_style_todos: false
+    one_member_abstracts: false
+    avoid_function_literals_in_foreach_calls: false


### PR DESCRIPTION
## 概要
- lint(静的解析) を適用
### 対応するIssues番号


## なぜやったか
- constのつけ忘れ検知や、indent等のコード規則を厳密にするため

## 変更点
- analysis_options.yamlを入れた

## 参考
- https://www.google.com/search?q=analysis_options.yaml&rlz=1C5CHFA_enJP852JP852&oq=analysis_op&aqs=chrome.1.69i57j0l5j69i61j69i60.4162j0j7&sourceid=chrome&ie=UTF-8

## その他
