### PR TITLE
lintが効かない問題の修正

### DIFF
--- a/.idea/morning_weakers.iml
+++ b/.idea/morning_weakers.iml
@@ -10,5 +10,6 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -102,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic_mono:
+    dependency: "direct dev"
+    description:
+      name: pedantic_mono
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic_mono: any
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 概要
- lintが効かない問題の修正
### 対応するIssues番号


## なぜやったか
- lintが効かなかった

## 変更点
- pubspec.ymlに依存関係を書いてなかった
