### PR TITLE
fix to reflect gitignore about .idea/modules.xml

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/morning_weakers.iml" filepath="$PROJECT_DIR$/.idea/morning_weakers.iml" />
-    </modules>
-  </component>
-</project>


### PR DESCRIPTION
## 概要
- .idea/modules.xmlに関して、gitignoreが反映されていなかったので反映させた

## なぜやったか
- 余計な差分感知

## 変更点
- .idea/modules.xmlをgitの監視対象外に変更
