### PR TITLE
add Drawer

### DIFF
--- a/lib/pages/home/drawer/home_drawer.dart
+++ b/lib/pages/home/drawer/home_drawer.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class HomeDrawer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            flex: 2,
+            child: _allGroups(),
+          ),
+          Expanded(
+            flex: 5,
+            child: _menus(),
+          )
+        ],
+      ),
+    );
+  }
+
+  Widget _menus() {
+    final List<String> _eventDetail = [
+      'これは概要ですが、特に思いつくことがないので、何も書きません。',
+      '2020/6/7 ~ 2020/6/14',
+      'Twitterでの投票',
+    ];
+
+    final List<List<String>> _buttons = [
+      ['All Groups', '/navigation'],
+      ['All Participants', '/navigation'],
+      ['Edit My Info', '/navigation'],
+    ];
+
+    return Container(
+      child: Column(
+        children: <Widget>[
+          DrawerHeader(
+            child: Center(
+              child: Text(
+                'CyberAgent21 Hackathon',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            decoration: BoxDecoration(color: Colors.lightBlueAccent),
+          ),
+          Expanded(
+            child: ListView(
+              shrinkWrap: true,
+              children: <Widget>[
+                Column(
+                  children: _eventDetail
+                      .map(
+                        (detail) => Container(
+                          padding: const EdgeInsets.all(10),
+                          child: Text(detail),
+                        ),
+                      )
+                      .toList(),
+                ),
+                Column(
+                  children: _buttons
+                      .map(
+                        (button) => ListTile(
+                          title: Text(
+                            button[0],
+                            style: const TextStyle(fontSize: 15),
+                          ),
+                          trailing: Icon(Icons.arrow_forward_ios),
+                          //onTap: () => button[1],
+                        ),
+                      )
+                      .toList(),
+                )
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _allGroups() {
+    final List<Widget> groups = [
+      Icon(Icons.people, size: 50),
+      Icon(Icons.people_outline, size: 50),
+      Icon(Icons.people, size: 50),
+      Icon(Icons.people_outline, size: 50),
+      Icon(Icons.people, size: 50),
+      Icon(Icons.people_outline, size: 50),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(10),
+      child: Column(children: [
+        ListView(
+          shrinkWrap: true,
+          children: groups,
+        ),
+        Icon(
+          Icons.add,
+          size: 50,
+        ),
+      ]),
+    );
+  }
+}

--- a/lib/pages/home/drawer/home_drawer.dart
+++ b/lib/pages/home/drawer/home_drawer.dart
@@ -21,13 +21,13 @@ class HomeDrawer extends StatelessWidget {
   }
 
   Widget _menus() {
-    final List<String> _eventDetail = [
+    final List<String> eventDetails = [
       'これは概要ですが、特に思いつくことがないので、何も書きません。',
       '2020/6/7 ~ 2020/6/14',
       'Twitterでの投票',
     ];
 
-    final List<List<String>> _buttons = [
+    final List<List<String>> buttons = [
       ['All Groups', '/navigation'],
       ['All Participants', '/navigation'],
       ['Edit My Info', '/navigation'],
@@ -36,7 +36,7 @@ class HomeDrawer extends StatelessWidget {
     return Container(
       child: Column(
         children: <Widget>[
-          DrawerHeader(
+          const DrawerHeader(
             child: Center(
               child: Text(
                 'CyberAgent21 Hackathon',
@@ -51,10 +51,9 @@ class HomeDrawer extends StatelessWidget {
           ),
           Expanded(
             child: ListView(
-              shrinkWrap: true,
               children: <Widget>[
                 Column(
-                  children: _eventDetail
+                  children: eventDetails
                       .map(
                         (detail) => Container(
                           padding: const EdgeInsets.all(10),
@@ -64,7 +63,7 @@ class HomeDrawer extends StatelessWidget {
                       .toList(),
                 ),
                 Column(
-                  children: _buttons
+                  children: buttons
                       .map(
                         (button) => ListTile(
                           title: Text(

--- a/lib/pages/home/drawer/home_drawer.dart
+++ b/lib/pages/home/drawer/home_drawer.dart
@@ -71,7 +71,7 @@ class HomeDrawer extends StatelessWidget {
                             button[0],
                             style: const TextStyle(fontSize: 15),
                           ),
-                          trailing: Icon(Icons.arrow_forward_ios),
+                          trailing: const Icon(Icons.arrow_forward_ios),
                           //onTap: () => button[1],
                         ),
                       )
@@ -102,7 +102,7 @@ class HomeDrawer extends StatelessWidget {
           shrinkWrap: true,
           children: groups,
         ),
-        Icon(
+        const Icon(
           Icons.add,
           size: 50,
         ),

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:morning_weakers/pages/home/drawer/home_drawer.dart';
 
 class HomePage extends StatelessWidget {
   @override
@@ -21,6 +22,7 @@ class HomePage extends StatelessWidget {
             ],
           ),
         ),
+        drawer: HomeDrawer(),
       ),
     );
   }


### PR DESCRIPTION
## 概要
- ドロワー作った

### 対応するIssues番号
close https://github.com/CA21engineer/morning-weakers/issues/24

## なぜやったか
- drawerがあった方が良いでしょ？

## スクリーンショット
Before|After
--|--
<img src="" width="300px">|<img src="https://user-images.githubusercontent.com/38239244/84237562-89657c00-ab34-11ea-8035-1f6b988e0a0d.png" width="300px">

## 変更点
- 

## 参考
- 

## その他
- slackみたいにhome画面がスライドするようにdrawerが出てきたら良いな
- 概要とか日にちとか一個一個タイトルつけるのはロジック組むときにやります
