### PR TITLE
グループ分け結果画面作ったUI

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:morning_weakers/pages/all/all_page.dart';
+import 'package:morning_weakers/pages/group_result/group_result_page.dart';
 import 'package:morning_weakers/pages/login/login_page.dart';
 import 'package:morning_weakers/pages/home/home_page.dart';
 import 'package:morning_weakers/pages/input_participant_info/input_participant_info_page.dart';
@@ -70,6 +71,10 @@ class MyApp extends StatelessWidget {
             case '/stateManagementSample':
               return MaterialPageRoute<void>(
                 builder: (_) => StateManagementSamplePage(),
+              );
+            case '/groupResultPage':
+              return MaterialPageRoute<void>(
+                builder: (_) => GroupResultPage(),
               );
             default:
               throw UnimplementedError('Undefined route ${settings.name}');

--- a/lib/pages/all/all_page.dart
+++ b/lib/pages/all/all_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:morning_weakers/pages/group_result/group_result_page.dart';
 import 'package:morning_weakers/pages/home/home_page.dart';
 import 'package:morning_weakers/pages/login/login_page.dart';
 import 'package:morning_weakers/pages/input_participant_info/input_participant_info_page.dart';
@@ -24,6 +25,7 @@ class AllPage extends StatelessWidget {
       SamplePage(),
       AdminGroupEditPage(),
       StateManagementSamplePage(),
+      GroupResultPage(),
     ];
 
     final List<String> _pageRouteNames = [
@@ -34,6 +36,8 @@ class AllPage extends StatelessWidget {
       '/home',
       '/adminTopPage',
       '/sample',
+      '/stateManagementSample',
+      '/groupResultPage'
       '/adminGroupEditPage',
       '/stateManagementSample',
     ];

--- a/lib/pages/all/all_page.dart
+++ b/lib/pages/all/all_page.dart
@@ -37,7 +37,7 @@ class AllPage extends StatelessWidget {
       '/adminTopPage',
       '/sample',
       '/stateManagementSample',
-      '/groupResultPage'
+      '/groupResultPage',
       '/adminGroupEditPage',
       '/stateManagementSample',
     ];

--- a/lib/pages/group_result/group_result_page.dart
+++ b/lib/pages/group_result/group_result_page.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class GroupResultPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    const String tomLink =
+        'https://pbs.twimg.com/profile_images/711875358149062656/pSW1TCfr_400x400.jpg';
+    const List<List<String>> data = [
+      [tomLink, 'tom', 'server'],
+      [tomLink, 'tom', 'server'],
+      [tomLink, 'tom', 'server'],
+      [tomLink, 'tom', 'server'],
+    ];
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('グループ分け結果')),
+      body: Container(
+        padding: const EdgeInsets.all(4),
+        child: GridView.count(
+            shrinkWrap: true,
+            childAspectRatio: 0.1,
+            crossAxisCount: 2,
+            children: <Widget>[
+              SingleChildScrollView(
+                child: Card(
+                  color: Colors.lightBlueAccent,
+                  child: Container(
+                    margin: const EdgeInsets.all(12),
+                    child: Column(
+                      children: <Widget>[
+                        Text(
+                          '朝弱いけん',
+                          style: TextStyle(
+                              fontSize: 20,
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold),
+                        ),
+                        Column(
+                          children: data
+                              .map((e) => ListTile(
+                                    leading: CircleAvatar(
+                                      radius: 20,
+                                      backgroundImage: NetworkImage(e[0]),
+                                      backgroundColor: Colors.transparent,
+                                    ),
+                                    title: Text(e[1]),
+                                    subtitle: Text(e[2]),
+                                  ))
+                              .toList(),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ]),
+      ),
+    );
+  }
+}

--- a/lib/pages/group_result/group_result_page.dart
+++ b/lib/pages/group_result/group_result_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 class GroupResultPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+
+    //TODO:dummyData
     const String tomLink =
         'https://pbs.twimg.com/profile_images/711875358149062656/pSW1TCfr_400x400.jpg';
     const List<List<String>> data = [
@@ -24,29 +26,31 @@ class GroupResultPage extends StatelessWidget {
             children: <Widget>[
               SingleChildScrollView(
                 child: Card(
-                  color: Colors.lightBlueAccent,
                   child: Container(
                     margin: const EdgeInsets.all(12),
                     child: Column(
                       children: <Widget>[
-                        Text(
+                        const Text(
                           '朝弱いけん',
                           style: TextStyle(
-                              fontSize: 20,
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold),
+                            fontSize: 20,
+                            color: Colors.black,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                         Column(
                           children: data
-                              .map((e) => ListTile(
-                                    leading: CircleAvatar(
-                                      radius: 20,
-                                      backgroundImage: NetworkImage(e[0]),
-                                      backgroundColor: Colors.transparent,
-                                    ),
-                                    title: Text(e[1]),
-                                    subtitle: Text(e[2]),
-                                  ))
+                              .map(
+                                (e) => ListTile(
+                                  leading: CircleAvatar(
+                                    radius: 20,
+                                    backgroundImage: NetworkImage(e[0]),
+                                    backgroundColor: Colors.transparent,
+                                  ),
+                                  title: Text(e[1]),
+                                  subtitle: Text(e[2]),
+                                ),
+                              )
                               .toList(),
                         ),
                       ],


### PR DESCRIPTION
## 概要
- グループ分けの結果画面を作成した
### 対応するIssues番号
close https://github.com/CA21engineer/morning-weakers/issues/25

## なぜやったか
- 結果が見れんとつらいけん


## スクリーンショット
Before|After
--|--
ないけん|<img src="https://user-images.githubusercontent.com/38239244/84561869-e5294280-ad8a-11ea-9570-1f3cc5eb5ad1.png" width="300px">

## 変更点
- 

## 参考
- 

## その他

