### PR TITLE
グループ分け結果画面のロジック

### DIFF
--- a/lib/pages/group_result/group_result_card_widget.dart
+++ b/lib/pages/group_result/group_result_card_widget.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:morning_weakers/pages/group_result/group_result_state.dart';
-import 'package:provider/provider.dart';
-import 'package:morning_weakers/models/models.dart';
 
 //TODO: cardの中身でwidget切り分けた方がいいかな？いらなければPR時に消します.
 class GroupResultCardWidget extends StatelessWidget {

--- a/lib/pages/group_result/group_result_card_widget.dart
+++ b/lib/pages/group_result/group_result_card_widget.dart
@@ -8,7 +8,7 @@ import 'package:morning_weakers/models/models.dart';
 class GroupResultCardWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final List<Group> groups = context.select<GroupResultState, List<Group>>((state) => state.hackathon.groups);
+    //final List<Group> groups = context.select<GroupResultState, List<Group>>((state) => state.hackathon.groups);
     return const Text('a');
   }
 }

--- a/lib/pages/group_result/group_result_card_widget.dart
+++ b/lib/pages/group_result/group_result_card_widget.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:morning_weakers/pages/group_result/group_result_state.dart';
+import 'package:provider/provider.dart';
+import 'package:morning_weakers/models/models.dart';
+
+//TODO: cardの中身でwidget切り分けた方がいいかな？いらなければPR時に消します.
+class GroupResultCardWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final List<Group> groups = context.select<GroupResultState, List<Group>>((state) => state.hackathon.groups);
+    return const Text('a');
+  }
+}

--- a/lib/pages/group_result/group_result_controller.dart
+++ b/lib/pages/group_result/group_result_controller.dart
@@ -1,0 +1,18 @@
+import 'package:morning_weakers/core/dummy_data.dart';
+import 'package:morning_weakers/models/models.dart';
+import 'package:morning_weakers/pages/group_result/group_result_state.dart';
+import 'package:state_notifier/state_notifier.dart';
+
+class GroupResultController extends StateNotifier<GroupResultState> with LocatorMixin {
+  GroupResultController() : super(const GroupResultState());
+
+  @override
+  void initState() {
+    getGroupResult();
+  }
+
+  Future<void> getGroupResult() {
+    final Hackathon hackathon = dummyHackathon();
+    state = state.copyWith(hackathon: hackathon);
+  }
+}

--- a/lib/pages/group_result/group_result_list_widget.dart
+++ b/lib/pages/group_result/group_result_list_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:morning_weakers/pages/group_result/group_result_state.dart';
+import 'package:provider/provider.dart';
+import 'package:morning_weakers/models/models.dart';
+
+class GroupResultListWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final List<Group> groups = context.select<GroupResultState, List<Group>>((state) => state.hackathon.groups);
+
+    return GridView.count(
+      shrinkWrap: true,
+      childAspectRatio: 0.1,
+      crossAxisCount: 2,
+      children: groups
+          .map(
+            (group) => SingleChildScrollView(
+              child: Card(
+                child: Container(
+                  margin: const EdgeInsets.all(12),
+                  child: Column(
+                    children: <Widget>[
+                      Text(
+                        group.groupName,
+                        style: const TextStyle(
+                          fontSize: 20,
+                          color: Colors.black,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Column(
+                        children: group.participants
+                            .map(
+                              (participant) => ListTile(
+                                leading: CircleAvatar(
+                                  radius: 20,
+                                  backgroundImage: NetworkImage(participant.user.iconUrl),
+                                  backgroundColor: Colors.transparent,
+                                ),
+                                title: Text(participant.user.displayName),
+                                subtitle: Text(participant.desiredOccupations[0].stack.getValue()),
+                              ),
+                            )
+                            .toList(),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/pages/group_result/group_result_page.dart
+++ b/lib/pages/group_result/group_result_page.dart
@@ -1,64 +1,21 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_state_notifier/flutter_state_notifier.dart';
+import 'package:morning_weakers/pages/group_result/group_result_controller.dart';
+import 'package:morning_weakers/pages/group_result/group_result_list_widget.dart';
+import 'package:morning_weakers/pages/group_result/group_result_state.dart';
 
 class GroupResultPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-
-    //TODO:dummyData
-    const String tomLink =
-        'https://pbs.twimg.com/profile_images/711875358149062656/pSW1TCfr_400x400.jpg';
-    const List<List<String>> data = [
-      [tomLink, 'tom', 'server'],
-      [tomLink, 'tom', 'server'],
-      [tomLink, 'tom', 'server'],
-      [tomLink, 'tom', 'server'],
-    ];
-
     return Scaffold(
       appBar: AppBar(title: const Text('グループ分け結果')),
-      body: Container(
-        padding: const EdgeInsets.all(4),
-        child: GridView.count(
-            shrinkWrap: true,
-            childAspectRatio: 0.1,
-            crossAxisCount: 2,
-            children: <Widget>[
-              SingleChildScrollView(
-                child: Card(
-                  child: Container(
-                    margin: const EdgeInsets.all(12),
-                    child: Column(
-                      children: <Widget>[
-                        const Text(
-                          '朝弱いけん',
-                          style: TextStyle(
-                            fontSize: 20,
-                            color: Colors.black,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        Column(
-                          children: data
-                              .map(
-                                (e) => ListTile(
-                                  leading: CircleAvatar(
-                                    radius: 20,
-                                    backgroundImage: NetworkImage(e[0]),
-                                    backgroundColor: Colors.transparent,
-                                  ),
-                                  title: Text(e[1]),
-                                  subtitle: Text(e[2]),
-                                ),
-                              )
-                              .toList(),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ]),
+      body: StateNotifierProvider<GroupResultController, GroupResultState>(
+        create: (_) => GroupResultController(),
+        child: Container(
+          padding: const EdgeInsets.all(4),
+          child: GroupResultListWidget(),
+        ),
       ),
     );
   }

--- a/lib/pages/group_result/group_result_state.dart
+++ b/lib/pages/group_result/group_result_state.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:morning_weakers/models/models.dart';
+
+part 'group_result_state.freezed.dart';
+
+@freezed
+abstract class GroupResultState with _$GroupResultState {
+  const factory GroupResultState({
+    Hackathon hackathon,
+  }) = _GroupResultState;
+}

--- a/lib/pages/group_result/group_result_state.freezed.dart
+++ b/lib/pages/group_result/group_result_state.freezed.dart
@@ -1,0 +1,148 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+
+part of 'group_result_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+class _$GroupResultStateTearOff {
+  const _$GroupResultStateTearOff();
+
+  _GroupResultState call({Hackathon hackathon}) {
+    return _GroupResultState(
+      hackathon: hackathon,
+    );
+  }
+}
+
+// ignore: unused_element
+const $GroupResultState = _$GroupResultStateTearOff();
+
+mixin _$GroupResultState {
+  Hackathon get hackathon;
+
+  $GroupResultStateCopyWith<GroupResultState> get copyWith;
+}
+
+abstract class $GroupResultStateCopyWith<$Res> {
+  factory $GroupResultStateCopyWith(
+          GroupResultState value, $Res Function(GroupResultState) then) =
+      _$GroupResultStateCopyWithImpl<$Res>;
+  $Res call({Hackathon hackathon});
+
+  $HackathonCopyWith<$Res> get hackathon;
+}
+
+class _$GroupResultStateCopyWithImpl<$Res>
+    implements $GroupResultStateCopyWith<$Res> {
+  _$GroupResultStateCopyWithImpl(this._value, this._then);
+
+  final GroupResultState _value;
+  // ignore: unused_field
+  final $Res Function(GroupResultState) _then;
+
+  @override
+  $Res call({
+    Object hackathon = freezed,
+  }) {
+    return _then(_value.copyWith(
+      hackathon:
+          hackathon == freezed ? _value.hackathon : hackathon as Hackathon,
+    ));
+  }
+
+  @override
+  $HackathonCopyWith<$Res> get hackathon {
+    if (_value.hackathon == null) {
+      return null;
+    }
+    return $HackathonCopyWith<$Res>(_value.hackathon, (value) {
+      return _then(_value.copyWith(hackathon: value));
+    });
+  }
+}
+
+abstract class _$GroupResultStateCopyWith<$Res>
+    implements $GroupResultStateCopyWith<$Res> {
+  factory _$GroupResultStateCopyWith(
+          _GroupResultState value, $Res Function(_GroupResultState) then) =
+      __$GroupResultStateCopyWithImpl<$Res>;
+  @override
+  $Res call({Hackathon hackathon});
+
+  @override
+  $HackathonCopyWith<$Res> get hackathon;
+}
+
+class __$GroupResultStateCopyWithImpl<$Res>
+    extends _$GroupResultStateCopyWithImpl<$Res>
+    implements _$GroupResultStateCopyWith<$Res> {
+  __$GroupResultStateCopyWithImpl(
+      _GroupResultState _value, $Res Function(_GroupResultState) _then)
+      : super(_value, (v) => _then(v as _GroupResultState));
+
+  @override
+  _GroupResultState get _value => super._value as _GroupResultState;
+
+  @override
+  $Res call({
+    Object hackathon = freezed,
+  }) {
+    return _then(_GroupResultState(
+      hackathon:
+          hackathon == freezed ? _value.hackathon : hackathon as Hackathon,
+    ));
+  }
+}
+
+class _$_GroupResultState
+    with DiagnosticableTreeMixin
+    implements _GroupResultState {
+  const _$_GroupResultState({this.hackathon});
+
+  @override
+  final Hackathon hackathon;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'GroupResultState(hackathon: $hackathon)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'GroupResultState'))
+      ..add(DiagnosticsProperty('hackathon', hackathon));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _GroupResultState &&
+            (identical(other.hackathon, hackathon) ||
+                const DeepCollectionEquality()
+                    .equals(other.hackathon, hackathon)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(hackathon);
+
+  @override
+  _$GroupResultStateCopyWith<_GroupResultState> get copyWith =>
+      __$GroupResultStateCopyWithImpl<_GroupResultState>(this, _$identity);
+}
+
+abstract class _GroupResultState implements GroupResultState {
+  const factory _GroupResultState({Hackathon hackathon}) = _$_GroupResultState;
+
+  @override
+  Hackathon get hackathon;
+  @override
+  _$GroupResultStateCopyWith<_GroupResultState> get copyWith;
+}


### PR DESCRIPTION
## 概要
- グループ分け画面結果のロジック
### 対応するIssues番号
close https://github.com/CA21engineer/morning-weakers/issues/70

## なぜやったか
- ロジック作りたいから！！

## スクリーンショット
Before|After
--|--
<img src="" width="300px">|<img src="https://user-images.githubusercontent.com/38239244/84565182-56282480-ada2-11ea-9abc-994995ab90ab.png" width="300px">

## 変更点
- 

## 参考
- 

## その他
